### PR TITLE
Add hunk tool

### DIFF
--- a/tools/hunk/Dockerfile.template
+++ b/tools/hunk/Dockerfile.template
@@ -1,0 +1,21 @@
+#syntax=docker/dockerfile:1.25.0@sha256:0adf442eae370b6087e08edc7c50b552d80ddf261576f4ebd6421006b2461f12
+
+FROM ghcr.io/uniget-org/tools/node-lts:latest AS node
+
+FROM registry.gitlab.com/uniget-org/images/ubuntu:26.04@sha256:e949a11db56b186fbed29acb3e6b04119b90e981d1eb1fff68013ba83a0ab38f AS prepare
+COPY --from=ghcr.io/uniget-org/tools/uniget-build:latest \
+    /etc/profile.d/ \
+    /etc/profile.d/
+SHELL [ "bash", "-clo", "errexit" ]
+ARG name
+ARG version
+COPY --link --from=node / /usr/local/
+WORKDIR /uniget_bootstrap/libexec/hunk
+ARG name
+ARG version
+RUN <<EOF
+npm install \
+    --omit=dev \
+    "hunkdiff@${version}"
+ln --symbolic --relative --force "${prefix}/libexec/hunk/node_modules/.bin/hunk" "${prefix}/bin/"
+EOF

--- a/tools/hunk/manifest.yaml
+++ b/tools/hunk/manifest.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://tools.uniget.dev/schema.yaml
+$schema: https://tools.uniget.dev/schema.yaml
+name: hunk
+description: Review-first terminal diff viewer for agentic coders
+license:
+  name: MIT License
+  link: https://github.com/modem-dev/hunk/blob/main/LICENSE
+homepage: https://hunk.dev
+repository: https://github.com/modem-dev/hunk
+version: "0.16.0"
+tags:
+- category/development
+- type/cli
+- lang/javascript
+- ai
+- llm
+- coding
+- agent
+- mcp
+- terminal
+- tui
+- vcs/git
+check: ${binary} --version
+build_dependencies:
+- node-lts
+runtime_dependencies:
+- node-lts
+platforms:
+- linux/amd64
+- linux/arm64
+renovate:
+  datasource: npm
+  package: hunkdiff


### PR DESCRIPTION
This PR adds the hunk tool, which is a review-first terminal diff viewer for agentic coders.

## Description
Hunk is optimized for reviewing a full changeset interactively and includes features like:
- Multi-file review stream with sidebar navigation
- Inline AI and agent annotations
- Split, stack, and responsive auto layouts
- Watch mode for auto-reloading

The tool is packaged via npm as .

## Checklist
- [x] Created 
- [x] Created 
- [x] Verified the build locally (logs check)
- [x] Verified tags and dependencies