### PR TITLE
fix(agent-manager): correct license to Apache License 2.0

### DIFF
--- a/tools/agent-manager/manifest.yaml
+++ b/tools/agent-manager/manifest.yaml
@@ -3,7 +3,7 @@ $schema: https://tools.uniget.dev/schema.yaml
 name: agent-manager
 description: Terminal UI to manage AI coding-agent sessions (Claude Code, OpenCode, Codex, Grok, Gemini CLI) in tmux
 license:
-  name: MIT License
+  name: Apache License 2.0
   link: https://github.com/YoanWai/agent-manager/blob/main/LICENSE
 homepage: https://agent-manager.dev
 repository: https://github.com/YoanWai/agent-manager


### PR DESCRIPTION
agent-manager is licensed under Apache-2.0, not MIT. The linked LICENSE file (https://github.com/YoanWai/agent-manager/blob/main/LICENSE) is the Apache License, Version 2.0, and the repository's GitHub license label says Apache-2.0.

Matches the wording other manifests use, for example tools/kubectl/manifest.yaml.

I maintain agent-manager. Thanks for packaging it.