### PR TITLE
feat(portless): Added

### DIFF
--- a/tools/portless/Dockerfile.template
+++ b/tools/portless/Dockerfile.template
@@ -1,0 +1,21 @@
+#syntax=docker/dockerfile:1.26.0@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
+
+FROM ghcr.io/uniget-org/tools/node-lts:latest AS node
+FROM ghcr.io/uniget-org/tools/npm:latest AS npm
+
+FROM registry.gitlab.com/uniget-org/images/ubuntu:26.04@sha256:b0b654de801604e256237f2c27a907a4b61b59ebd83423ad0e0e465c0a3ba9cd AS prepare
+COPY --from=ghcr.io/uniget-org/tools/uniget-build:latest \
+    /etc/profile.d/ \
+    /etc/profile.d/
+SHELL [ "bash", "-clo", "errexit" ]
+COPY --link --from=node / /usr/local/
+COPY --link --from=npm / /usr/local/
+WORKDIR /uniget_bootstrap/libexec/portless
+ARG name
+ARG version
+RUN <<EOF
+npm install \
+    --omit=dev \
+    "portless@${version}"
+ln --symbolic --relative --force "${prefix}/libexec/portless/node_modules/.bin/portless" "${prefix}/bin/"
+EOF

--- a/tools/portless/manifest.yaml
+++ b/tools/portless/manifest.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://tools.uniget.dev/schema.yaml
+$schema: https://tools.uniget.dev/schema.yaml
+name: portless
+description: Replace port numbers with stable, named local URLs for development
+license:
+  name: Apache-2.0
+  link: https://github.com/vercel-labs/portless/blob/main/LICENSE
+homepage: https://portless.sh
+repository: https://github.com/vercel-labs/portless
+version: "0.15.5"
+tags:
+- type/cli
+- category/development
+- lang/javascript
+- org/vercel
+check: ${binary} --version
+platforms:
+- linux/amd64
+renovate:
+  datasource: npm
+  package: portless


### PR DESCRIPTION
Adds portless - replaces port numbers with stable, named local URLs for development.

- Pattern: Node via npm installation
- Platform: linux/amd64
- Renovate: npm
- Requires Node.js at runtime